### PR TITLE
testing tweaks

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,6 +51,8 @@ class DummyVentilator(DivideAndConquerVentilator):
         socket.send_pyobj(number)
 
     def produce(self):
+         # temporary workaround for race with workers on first message
+        time.sleep(0.25)
         for i in range(50):
             yield i
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -86,6 +86,10 @@ class DummySink(DivideAndConquerSink):
 
     def setup_sockets(self, context, *args, **kwargs):
         super(DummySink, self).setup_sockets(context, *args, **kwargs)
+        self.publisher = publisher = self.context.socket(zmq.PUB)
+        # set SNDHWM, so we don't drop messages for slow subscribers
+        publisher.sndhwm = 1100000
+        publisher.bind('tcp://*:{}'.format(self.result_port))
 
     def process(self, number_squared):
         print('Received', number_squared, 'for processing')
@@ -95,11 +99,6 @@ class DummySink(DivideAndConquerSink):
     def shutdown(self):
         print('SHUTTING DOWN!', self.sum)
         self._receiver.close()
-        # Socket to talk to clients
-        publisher = self.context.socket(zmq.PUB)
-        # set SNDHWM, so we don't drop messages for slow subscribers
-        publisher.sndhwm = 1100000
-        publisher.bind('tcp://*:{}'.format(self.result_port))
 
         # Socket to receive signals
         syncservice = self.context.socket(zmq.REP)
@@ -108,7 +107,7 @@ class DummySink(DivideAndConquerSink):
         syncservice.recv()
         # send synchronization reply
         syncservice.send(b'')
-        publisher.send_pyobj(self.sum)
+        self.publisher.send_pyobj(self.sum)
 
 
 def test_localhost_divide_and_conquer_manager():
@@ -121,7 +120,6 @@ def test_localhost_divide_and_conquer_manager():
                                                          sync_port),
                                                [DummyWorker(), DummyWorker()],
                                                ventilator_port, sink_port)
-    context = zmq.Context()
     manager.launch()
     context = zmq.Context()
 


### PR DESCRIPTION
- avoid slow-subscriber problem on the publisher by creating it along with other sockets.
- avoid race between vent and workers on sink with a sleep. This should really be fixed with a different message pattern, but works for the test.
